### PR TITLE
Started a README.md and reverted a few typos in pydocstring.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# PyDocString
+`pydocstring` is a tool used to parse a function and its docstring for further marking. It extracts features from the docstring including:
+
+- TypeContract
+- Description
+- Requirements
+- Examples
+
+
+## Example of a Design Recipe function:
+
+```python
+def divide(numerator, denominator):
+    ''' (float, float) -> float
+    # This is a function that divides one number by the other.
+    REQ: denominator != 0
+    >>> divide(1, 2)
+    0.5
+    >>> divide(2, 2)
+    1.0
+    '''
+    # Get the quotient of the division.
+    quotient = numerator / denominator
+    # Return the quotient
+    return quotient
+```

--- a/pydocstring.py
+++ b/pydocstring.py
@@ -126,7 +126,7 @@ class Example():
 
 if __name__ == "__main__":
     def func1(a_str, a_int, a_float, a_list, a_dict):
-        ''' (str, int, float, DocString, dict of {str: int}) -> bool
+        ''' (str, int, float, list of str, dict of {str: int}) -> bool
         This is a sample doc, this line is not too long.
         This line is a bit longer than expected, we need to break this
         line into two.
@@ -144,7 +144,7 @@ if __name__ == "__main__":
 
 
     def func2(a_str, a_int, a_float, a_list, a_dict):
-        ''' (str, int, float, DocString, dict of {str: int}) -> (bool, float, list of int)
+        ''' (str, int, float, list of str, dict of {str: int}) -> (bool, float, list of int)
         REQ: this is a requirement
         REQ: another requirement
         requirement: possibly another requirement like this
@@ -162,7 +162,6 @@ if __name__ == "__main__":
 
 doc = DocString(func1)
 print(doc._requirements._requirements)
-print(doc._examples._examples)
 print(str(doc.get_type_contract()))
 doc2 = DocString(func2)
 doc2_tc = doc2.get_type_contract()


### PR DESCRIPTION
I made a README.md and changed back instances of `DocString` back to `list of str` inside the sample docstrings.