### PR TITLE
Fix some PEP 8 issues add parsing for inline type contract

### DIFF
--- a/pydocstring.py
+++ b/pydocstring.py
@@ -1,15 +1,18 @@
-class DocString():
-    ''' python docstring object, apply PEP-257 docstring style checking '''
+class DocString:
+    """ python docstring object, apply PEP-257 docstring style checking """
 
     def __init__(self, function):
-        ''' (DocString, str) -> None
+        """ (DocString, str) -> None
         Initialize a DocString constructor.
 
-        Note: we have second option here, instead of taking doc, we can also take in the function object,
-        then save the doc by calling func.__doc__, so that we have kept both docstring and function itself for reference
-        '''
+        Note: we have second option here, instead of taking doc, we can also
+        take in the function object,
+        then save the doc by calling func.__doc__, so that we have kept both
+        docstring and function itself for reference
+        """
         self.doc = function.__doc__
-        self._doc_list = list(map(str.strip, self.doc.split('\n')))  # if successfully parsed docstring, this eventually become empty list
+        self._doc_list = list(map(str.strip, self.doc.split('\n')))
+        # if successfully parsed docstring, this^ eventually becomes empty list
         self._type_contract = self._parse_type_contract()
         self._description = self._parse_description()
         self._requirements = self._parse_requirements()
@@ -19,43 +22,53 @@ class DocString():
         return self.doc
 
     def get_type_contract(self):
-        ''' (DocString) -> TypeContract
+        """ (DocString) -> TypeContract
         Return the TypeContract object
-        '''
+        """
         return self._type_contract
 
     def get_description(self):
-        ''' (DocString) -> Description
+        """ (DocString) -> Description
         Return the Description object
-        '''
+        """
         return self._description
 
     def get_requirement(self):
-        ''' (DocString) -> Requirement
+        """ (DocString) -> Requirement
         Return the Requirement object
-        '''
+        """
         return self._requirement
 
     def _parse_type_contract(self):
         """ (DocString) -> dict of {str: list of str}
-        Returns a dictionary that contains a list of strings representing the inputs, and another list of strings
+        Returns a dictionary that contains a list of strings representing
+        the inputs, and another list of strings
         representing the outputs of the type contract
         """
         # get the type contract as a string
-        type_contract = ''.join(list(filter(lambda d: '(' in d and ')' in d and '->' in d, self._doc_list)))
+        type_contract = ''.join(list(
+            filter(lambda d: '(' in d and ')' in d and '->' in d,
+                   self._doc_list)))
         # determine where the inputs and output start in the string
-        input_start, input_end = type_contract.find("(") + 1, type_contract.find(")")
-        output_start = type_contract.find("->") + 2 if "->" in type_contract else type_contract.find("-->") + 3
+        input_start, input_end = type_contract.find(
+            "(") + 1, type_contract.find(")")
+        output_start = type_contract.find(
+            "->") + 2 if "->" in type_contract else type_contract.find(
+            "-->") + 3
         # split the inputs by the comma, and remove any extra white space
-        inputs = [token.strip() for token in type_contract[input_start:input_end].split(",")]
+        inputs = [token.strip() for token in
+                  type_contract[input_start:input_end].split(",")]
         outputs = []
         outputs_str = type_contract[output_start:]
         if "(" in outputs_str and ")" in outputs_str:
-            # if parentheses are present in the outputs, remove them but only one
-            # occurrence. If they put too many brackets they should remain in the final output
+            # if parentheses are present in the outputs, remove them but
+            # only one
+            # occurrence. If they put too many brackets they should remain
+            # in the final output
             outputs_str = outputs_str.replace("(", "", 1)
             outputs_str = outputs_str.replace(")", "", 1)
-        # split the outputs string by commas and iterate through each token, removing
+        # split the outputs string by commas and iterate through each token,
+        #  removing
         # extra whitespace and matching parentheses if present
         for token in outputs_str.split(","):
             token = token.strip()
@@ -63,9 +76,9 @@ class DocString():
         return {"inputs": inputs, "outputs": outputs}
 
     def _parse_requirements(self):
-        ''' (DocString) -> Requirement
+        """ (DocString) -> Requirement
         Parses a given string (docstring) and extracts the description.
-        '''
+        """
         # Search for the beginning "req" case-insensitively
         requirements_list = []
         for item in self._doc_list:
@@ -75,21 +88,19 @@ class DocString():
         return Requirement(requirements_list)
 
     def _parse_description(self):
-        ''' (DocString) -> Description
+        """ (DocString) -> Description
         Parses a given string (docstring) and extracts the requirements.
-        '''
+        """
         return Description(None)
 
     def _parse_examples(self):
-        ''' (DocString) -> Example
+        """ (DocString) -> Example
         Parses a given string (docstring) and extracts the examples.
-        '''
+        """
         return Example(None)
 
 
-
-class TypeContract():
-
+class TypeContract:
     def __init__(self, arg_types, return_types):
         # Type contract should contain the arguments and return types
         self._arg_types = []
@@ -99,7 +110,7 @@ class TypeContract():
         return False
 
 
-class Description():
+class Description:
     def __init__(self, text):
         self._text = text
 
@@ -108,7 +119,7 @@ class Description():
         return self._text == other.text
 
 
-class Requirement():
+class Requirement:
     def __init__(self, requirements):
         # DocString can have multiple requirements.
         self._requirements = requirements
@@ -117,7 +128,7 @@ class Requirement():
         return False
 
 
-class Example():
+class Example:
     def __init__(self, examples):
         self._examples = examples
 
@@ -127,7 +138,7 @@ class Example():
 
 if __name__ == "__main__":
     def func1(a_str, a_int, a_float, a_list, a_dict):
-        ''' (str, int, float, DocString, dict of {str: int}) -> (bool)
+        """ (str, int, float, DocString, dict of {str: int}) -> (bool)
         This is a sample doc, this line is not too long.
         This line is a bit longer than expected, we need to break this
         line into two.
@@ -140,17 +151,19 @@ if __name__ == "__main__":
         True
         >>> func1('a', 1, 0.8, ['hello', 'world'], {'hi': 9})
         False
-        '''
+        """
         return False  # dummy code
 
 
     def func2(a_str, a_int, a_float, a_list, a_dict):
-        '''(str, int, float, DocString, dict of {str: int}) -> (bool, float, list of int)
+        """(str, int, float, DocString, dict of {str: int}) -> (bool, float,
+        list of int)
         REQ: this is a requirement
         REQ: another requirement
         requirement: possibly another requirement like this
 
-        This is another sample doc, this possibly requirements stated before description.
+        This is another sample doc, this possibly requirements stated before
+        description.
         This line is a bit longer than expected, we need to break this
         line into two.
 
@@ -158,7 +171,7 @@ if __name__ == "__main__":
         True
         >>> func2('a', 1, 0.8, ['hello', 'world'], {'hi': 9})
         False
-        '''
+        """
         return False  # dummy code
 
 doc = DocString(func1)

--- a/pydocstring.py
+++ b/pydocstring.py
@@ -21,6 +21,8 @@ class DocString:
 
     def _parse_inline_type_contract(self, func):
         type_list = list(func.__annotations__.values())
+        if type_list == []:
+            return TypeContract([], [])
         inputs = type_list[0:-1]
         outputs = type_list[-1]
         return TypeContract(inputs, outputs)
@@ -109,6 +111,10 @@ class DocString:
 
 
 class TypeContract:
+    def __str__(self) -> str:
+        return "intputs: {}, outputs: {}".format(self._arg_types,
+                                                 self._return_types)
+
     def __init__(self, arg_types, return_types):
         # Type contract should contain the arguments and return types
         self._arg_types = arg_types
@@ -164,6 +170,8 @@ if __name__ == "__main__":
 
 
     def func2(a_str, a_int, a_float, a_list, a_dict):
+        # TODO if you split the type contract to follow PEP 8 it will not
+        # fully parse
         """(str, int, float, DocString, dict of {str: int}) -> (bool, float,
         list of int)
         REQ: this is a requirement


### PR DESCRIPTION
- Changed the return type of `_parse_type_contract` to `TypeContract`
- Added string method to `TypeContract`
- Found a bug with parsing the type contract
    - if the type contract is split to multiple lines to follow PEP 8 syntax, the parsing algorithm breaks
- Changed name of `DocString` parameter since it could collide with bultin `function`