### PR TITLE
Added a grammar and parser for type contract parsing

### DIFF
--- a/pydocstring.py
+++ b/pydocstring.py
@@ -33,18 +33,13 @@ class DocString():
         return self._description
 
     def get_requirement(self):
-        ''' (DocString) -> list of str
+        ''' (DocString) -> Requirement
         Return the Requirement object
         '''
         return self._requirements
 
-    def get_examples(self):
-        '''(DocString) -> Example
-        Return the Example object
-        '''
-
     def _parse_type_contract(self):
-        ''' (DocString) -> dict of {str: list of str}
+        ''' (DocString) -> TypeContract
         Returns a dictionary that contains 2 lists: a list of input types and
         a list of output types
         '''
@@ -52,7 +47,7 @@ class DocString():
         return TypeContract(result["inputs"], result["outputs"])
 
     def _parse_requirements(self):
-        ''' (DocString) -> list of str
+        ''' (DocString) -> Requirement
         Parses a given string (docstring) and extracts the description.
         '''
         # Search for the beginning "req" case-insensitively
@@ -61,13 +56,13 @@ class DocString():
             if item[0:3].lower() == "req":
                 requirements_list.append(item)
 
-        return requirements_list
+        return Requirement(requirements_list)
 
     def _parse_description(self):
         ''' (DocString) -> Description
         Parses a given string (docstring) and extracts the requirements.
         '''
-        return "Pending Description"
+        return Description(None)
 
     def _parse_examples(self):
         ''' (DocString) -> Example

--- a/typecontract_parser.py
+++ b/typecontract_parser.py
@@ -1,0 +1,61 @@
+from parsy import *
+
+def flatten(container):
+    for i in container:
+        if isinstance(i, (list, tuple)):
+            for j in flatten(i):
+                yield j
+        else:
+            yield i
+
+@generate
+def LIST():
+    return (yield string("list of ") + ARG)
+
+@generate
+def SET():
+    return (yield string("set of ") + ARG)
+
+@generate
+def TUPLE():
+    result = (yield seq(string("tuple of ") << optional_lparen,
+              optional_whitespace >> ARG.many().sep_by(regex(r',\s*')) <<
+              (optional_whitespace + optional_rparen)))
+    return "".join(list(flatten(result)))
+
+@generate
+def DICT():
+    pair = ((ARG << optional_whitespace) +  string(":") +
+               (optional_whitespace >> ARG)).many().sep_by(regex(r',\s*'))
+    result = (yield seq(string("dict of {") << optional_whitespace) +
+              pair +  seq(optional_whitespace >> string("}")))
+    return (list(flatten(result)))
+
+@generate
+def INPUT():
+    result = (yield (optional_whitespace + lparen) >>
+              ARG.many().sep_by(regex(r',\s*')) << rparen)
+    return list(flatten(result))
+
+@generate
+def OUTPUT():
+    result = (yield seq(optional_whitespace, optional_lparen) >>
+              ARG.many().sep_by(regex(r',\s*')) <<
+              seq(optional_whitespace, optional_rparen))
+    return list(flatten(result))
+
+@generate
+def TC():
+    inputs = yield INPUT
+    yield (optional_whitespace + ARROW + optional_whitespace)
+    outputs = yield OUTPUT
+    return {'inputs': inputs, 'outputs': outputs}
+
+optional_whitespace = regex(r'\s*')
+optional_lparen = regex(r'\(?')
+optional_rparen = regex(r'\)?')
+lparen = string("(")
+rparen = string(")")
+TYPE = regex(r'\b[a-z|A-z]+\b')
+ARG = LIST | SET | TYPE
+ARROW = regex(r'[-|=]+>')


### PR DESCRIPTION
- Created a custom grammar to define what a type contract accepts
- Created a parser to parse and tokenize the type contract directly from the __doc__
- Currently supports all standard primitives and custom classes, as well as nested lists and sets
- Does not currently support dicts or tuples